### PR TITLE
Change from the 'expose' to 'ports' parameter in the db service to av…

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -95,7 +95,7 @@ services:
       - POSTGRES_PASSWORD=${PSQL_PGPASSWORD}
     profiles:
       - hiveexternal
-    expose:
+    ports:
       - "5432:5432"
     networks:
       hadoop_network:


### PR DESCRIPTION
…oid an error and publish the port on the host machine.

Problem

The following error occurs on "docker-compose build" command invocation:

ERROR: The Compose file './docker-compose.yml' is invalid because:
services.db.expose is invalid: should be of the format 'PORT[/PROTOCOL]'

According to Docker documentation, the expose parameter "Expose ports without publishing them to the host machine - they’ll only be accessible to linked services. Only the internal port can be specified." https://docs.docker.com/compose/compose-file/compose-file-v3/

Solution
One solution would be cut off the second port of the expose parameter value, but, in this case, the DB would be not accessible from a SQL client on the host machine and, maybe, it isn't desirable.

The chosen solution was change the 'expose' parameter to 'ports' parameter without changes in the parameter value.